### PR TITLE
Remove engine settings

### DIFF
--- a/chat-server/package.json
+++ b/chat-server/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "cors": "^2.8.5"
   },
-  "engines": {
-    "node": "8.x"
-  },
   "repository": {
     "url": "https://glitch.com/edit/#!/hello-express"
   },

--- a/hotel-bookings-api/package.json
+++ b/hotel-bookings-api/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "cors": "^2.8.5"
   },
-  "engines": {
-    "node": "8.x"
-  },
   "repository": {
     "url": "https://glitch.com/edit/#!/hello-express"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,6 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5"
-      },
-      "engines": {
-        "node": "8.x"
       }
     },
     "hotel-bookings-api": {
@@ -35,9 +32,6 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5"
-      },
-      "engines": {
-        "node": "8.x"
       }
     },
     "mailing-list-api": {


### PR DESCRIPTION
These cause a bunch of logspam when running things like `npm install`.

Node 8 was _ages_ ago, and hopefully not relevant.